### PR TITLE
vim에서 한글 상태일 때, escape를 한 번만 눌러도 normal 모드로 전환

### DIFF
--- a/md/with_korean.md
+++ b/md/with_korean.md
@@ -97,6 +97,9 @@ macOS를 위한 Karabiner-Elements가 현재 개발중이긴 한데, 아직까�
             {
               "select_input_source": {
                 "language": "en"
+              },
+              {
+                "key_code": "escape"
               }
             }
           ],

--- a/md/with_korean.md
+++ b/md/with_korean.md
@@ -97,10 +97,10 @@ macOS를 위한 Karabiner-Elements가 현재 개발중이긴 한데, 아직까�
             {
               "select_input_source": {
                 "language": "en"
-              },
-              {
-                "key_code": "escape"
               }
+            },
+            {
+              "key_code": "escape"
             }
           ],
           "conditions": [ 


### PR DESCRIPTION
karabiner 사용 시, escape를 한 번만 눌러도 영문 전환 및 normal 모드로 변경됩니다.